### PR TITLE
Don't allow zooming out until the zoom has started

### DIFF
--- a/js/zoom-vanilla.js
+++ b/js/zoom-vanilla.js
@@ -43,9 +43,9 @@
 			closeActiveZoom({ forceDispose: true })
 
 			activeZoom = vanillaZoom(event.target)
-			activeZoom.zoomImage()
-
-			addCloseActiveZoomListeners()
+			activeZoom.zoomImage({
+				onZoomStart: addCloseActiveZoomListeners
+			})
 		}
 
 		function openInNewWindow() {
@@ -119,7 +119,7 @@
 		var targetImageWrap = null
 		var targetImageClone = null
 
-		function zoomImage() {
+		function zoomImage(options) {
 			document.body.classList.add('zoom-overlay-active');
 			var img = document.createElement('img')
 
@@ -132,14 +132,14 @@
 
 				fullHeight = targetImage.getAttribute('data-full-height') // Number(img.height)
 				fullWidth = targetImage.getAttribute('data-full-width') // Number(img.width)
-				zoomOriginal()
+				zoomOriginal(options)
 			}
  			img.setAttribute('sizes', targetImage.getAttribute('sizes'));
  			img.setAttribute('srcset', targetImage.getAttribute('srcset'));
  			img.src = targetImage.src;
 		}
 
-		function zoomOriginal() {
+		function zoomOriginal(options) {
 			targetImageWrap = document.createElement('div')
 			targetImageWrap.className = 'zoom-img-wrap'
 			targetImageWrap.style.position = 'absolute'
@@ -170,6 +170,7 @@
 				triggerAnimation()
 
 				window.addEventListener('resize', resizeHandler);
+				options.onZoomStart()
 			});
 		}
 
@@ -226,6 +227,8 @@
 			document.body.classList.add('zoom-overlay-open')
 		}
 
+		var disposeTimeout = null
+
 		function close() {
 			window.removeEventListener('resize', resizeHandler);
 
@@ -244,11 +247,14 @@
 
 			targetImage.addEventListener('transitionend', dispose)
 			targetImage.addEventListener('webkitTransitionEnd', dispose)
+			// fallback if transitionend doesn't fire
+			disposeTimeout = setTimeout(dispose, 350)
 		}
 
 		function dispose() {
 			targetImage.removeEventListener('transitionend', dispose)
 			targetImage.removeEventListener('webkitTransitionEnd', dispose)
+			clearTimeout(disposeTimeout)
 
 			if (!targetImageWrap || !targetImageWrap.parentNode) return
 


### PR DESCRIPTION
Background
---

Our fork of zoom.js preloads the image before zooming it in. This is necessary because we don't know what image file to zoom until the user clicks.

Problem
---

Some things break if `close` gets called before `zoomOriginal` gets called. This happens if the image hasn't loaded yet. `close` expects the image to be in a "zoomed" state.

Solution
---

I briefly tried to make `close` more reliable no matter what state the zoomer is in, but I don't think it's worth it. It's a lot of changes for a feature we don't really need. It's also an odd user experience to "stop loading" by clicking twice.

Instead, just don't let `close` get called until the preload finishes.

Also, there is a rare case where `transitionend` won't fire if you zoom out right when the "zoom in" animation starts. Add a setTimeout fallback for this case.